### PR TITLE
Add toad-scheduler 3.x to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "peerDependencies": {
     "fastify": "^4.0.0",
-    "toad-scheduler": "^2.0.0"
+    "toad-scheduler": ">= 2.0.0 < 4"
   },
   "devDependencies": {
     "@fastify/pre-commit": "^2.0.2",
@@ -33,7 +33,7 @@
     "prettier": "^2.7.1",
     "standard": "^17.0.0",
     "tap": "^16.3.0",
-    "toad-scheduler": "^2.0.0",
+    "toad-scheduler": "^3.0.0",
     "tsd": "^0.28.0"
   },
   "homepage": "http://github.com/fastify/fastify-schedule",


### PR DESCRIPTION
Plugin should support toad-scheduler 3.0.0 without any changes, so peerDependencies were updated

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
