### PR TITLE
fix: migrate from tap to node test and c8

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,2 +1,0 @@
-files:
-  - test/**/*.test.js

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "types": "types/index.d.ts",
   "scripts": {
     "test": "npm run test:unit && npm run test:typescript",
-    "test:unit": "tap",
+    "test:unit": "c8 node --test",
     "test:typescript": "tsd",
     "lint": "standard",
     "lint:fix": "standard --fix"
@@ -28,12 +28,11 @@
   },
   "devDependencies": {
     "@fastify/pre-commit": "^2.1.0",
-    "@sinonjs/fake-timers": "^11.2.2",
     "@types/node": "^22.0.0",
+    "c8": "^10.1.2",
     "fastify": "^5.0.0-alpha.2",
     "prettier": "^3.2.5",
     "standard": "^17.1.0",
-    "tap": "^20.0.0",
     "toad-scheduler": "^3.0.1",
     "tsd": "^0.31.1"
   },

--- a/test/schedulePlugin.test.js
+++ b/test/schedulePlugin.test.js
@@ -2,16 +2,12 @@
 
 const fastify = require('fastify')
 const fastifySchedulePlugin = require('../index')
-const FakeTimers = require('@sinonjs/fake-timers')
-const test = require('tap').test
+const { test, mock } = require('node:test')
 const { SimpleIntervalJob, Task } = require('toad-scheduler')
 
 test('schedulePlugin correctly stops on application close', async (t) => {
-  const clock = FakeTimers.install()
-
-  t.teardown(() => {
-    clock.uninstall()
-  })
+  const clock = mock.timers
+  clock.enable(0)
 
   const app = fastify({ logger: true })
   app.register(fastifySchedulePlugin)
@@ -30,12 +26,12 @@ test('schedulePlugin correctly stops on application close', async (t) => {
 
   app.scheduler.addSimpleIntervalJob(job)
 
-  t.equal(counter, 0)
+  t.assert.equal(counter, 0)
   clock.tick(20)
-  t.equal(counter, 2)
+  t.assert.equal(counter, 2)
 
   await app.close()
   clock.tick(20)
 
-  t.equal(counter, 2)
+  t.assert.equal(counter, 2)
 })


### PR DESCRIPTION
#### Checklist

This PR migrates from `tap` to `node:test` and `c8`

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
