### PR TITLE
chore: remove redundant peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,11 +20,8 @@
     "lint:fix": "standard --fix"
   },
   "dependencies": {
-    "fastify-plugin": "^4.5.1"
-  },
-  "peerDependencies": {
-    "fastify": "^5.0.0",
-    "toad-scheduler": ">= 2.0.0 < 4"
+    "fastify-plugin": "^5.0.0",
+    "toad-scheduler": ">=2.0.0 <4"
   },
   "devDependencies": {
     "@fastify/pre-commit": "^2.1.0",


### PR DESCRIPTION
Peer Dependencies [use case](https://nodejs.org/en/blog/npm/peer-dependencies):

> There's one use case where this falls down, however: plugins. A plugin package is meant to be used with another "host" package, even though it does not always directly use the host package.

We always directly use `toad-scheduler` and we don't let the user pass a `toad-scheduler` instance, so I think having it as peerDep is unnecessary here:

https://github.com/fastify/fastify-schedule/blob/1e5554bfc6a93ae2c7d24f14adc8f6f55f054325/index.js#L6-L16

---

I can also change the range to `^3` but that might be breaking, not sure