### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@fastify/pre-commit": "^2.1.0",
     "@types/node": "^22.0.0",
     "c8": "^10.1.2",
+    "eslint": "^9.17.0",
     "fastify": "^5.0.0",
     "neostandard": "^0.12.0",
     "toad-scheduler": "^3.0.1",

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,9 +1,7 @@
-import { FastifyInstance, FastifyPluginCallback } from 'fastify'
-import fastify from 'fastify'
+import fastify, { FastifyInstance, FastifyPluginCallback } from 'fastify'
 import { expectType } from 'tsd'
 
-import { fastifySchedule as fastifyScheduleNamed } from '..'
-import fastifyScheduleDefault from '..'
+import fastifyScheduleDefault, { fastifySchedule as fastifyScheduleNamed } from '..'
 import * as fastifyScheduleStar from '..'
 import fastifyScheduleCjsImport = require('..')
 const fastifyScheduleCjs = require('./')


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.