### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ const job = new SimpleIntervalJob({ seconds: 20, }, task)
 fastify.register(fastifySchedulePlugin);
 
 // `fastify.scheduler` becomes available after initialization.
-// Therefore, you need to call `ready` method.
-fastify.ready().then(() => {
+// Therefore, you need to call `after` method.
+fastify.after().then(() => {
     fastify.scheduler.addSimpleIntervalJob(job)
 })
 ```


### PR DESCRIPTION
This PR addresses an issue where using the `ready` method causes the application to get stuck when running unit tests. To resolve this, the `after` method is used instead, ensuring that the necessary logic is executed without blocking the test execution.
Changes:

    Replaced `ready` method with `after` to prevent test execution from getting stuck.

Reason for Change:

    The `ready` method can introduce unexpected behavior in unit test environments, leading to tests hanging indefinitely.
    The `after` method ensures the required logic is executed after initialization without interfering with test execution.

Testing:

    Ran unit tests successfully without any hanging issues.
    Verified the functionality remains unchanged in the main application.