### PR TITLE
docs(readme): fix plugin name in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ const task = new AsyncTask(
 )
 const job = new SimpleIntervalJob({ seconds: 20, }, task)
 
-fastify.register(fastifySchedulePlugin);
+fastify.register(fastifySchedule);
 
 // `fastify.scheduler` becomes available after initialization.
 // Therefore, you need to call `ready` method.


### PR DESCRIPTION
Simple documentation update as it seems to be out of date:

Using the proper export name of the plugin


