### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/fastify/fastify-schedule.git"
+    "url": "git+https://github.com/fastify/fastify-schedule.git"
   },
   "bugs": {
     "url": "https://github.com/fastify/fastify-schedule/issues"


### PR DESCRIPTION
## Summary

- Update `package.json#repository.url` from the unauthenticated `git://` URL to the public HTTPS form.
- Keep the repository metadata pointing at the same upstream repository.

## Validation

- Checked the current npm metadata for `@fastify/schedule@6.0.0`.
- Parsed `package.json` and asserted `repository.url === "git+https://github.com/fastify/fastify-schedule.git"`.
- `git diff --check`
- `git ls-remote https://github.com/fastify/fastify-schedule.git HEAD`
